### PR TITLE
Adding more commands that PocketNano Uses

### DIFF
--- a/canoed
+++ b/canoed
@@ -305,6 +305,26 @@ function startRESTServer () {
         return accountsPending(spec).then((r) => { res.json(r) })
       case 'account_history':
         return accountHistory(spec).then((r) => { res.json(r) })
+      case 'account_get':
+        return accountGet(spec).then((r) => { res.json(r) })
+      case 'account_info':
+        return accountInfo(spec).then((r) => { res.json(r) })
+      case 'account_key':
+        return accountKey(spec).then((r) => { res.json(r) })
+      case 'validate_account_number':
+        return validateAccountNumber(spec).then((r) => { res.json(r) })
+      case 'krai_from_raw':
+        return doConversion(spec).then((r) => { res.json(r) })
+      case 'krai_to_raw':
+        return doConversion(spec).then((r) => { res.json(r) })
+      case 'mrai_from_raw':
+        return doConversion(spec).then((r) => { res.json(r) })
+      case 'mrai_to_raw':
+        return doConversion(spec).then((r) => { res.json(r) })
+      case 'rai_from_raw':
+        return doConversion(spec).then((r) => { res.json(r) })
+      case 'rai_to_raw':
+        return doConversion(spec).then((r) => { res.json(r) })
       case 'blocks_info':
         return blocksInfo(spec).then((r) => { res.json(r) })
       case 'work_generate':
@@ -355,6 +375,26 @@ function chain (spec) {
 }
 
 function accountHistory (spec) {
+  return callRainode(spec)
+}
+
+function accountGet (spec) {
+  return callRainode(spec)
+}
+
+function accountInfo (spec) {
+  return callRainode(spec)
+}
+
+function accountKey (spec) {
+  return callRainode(spec)
+}
+
+function validateAccountNumber (spec) {
+  return callRainode(spec)
+}
+
+function doConversion (spec) {
   return callRainode(spec)
 }
 


### PR DESCRIPTION
Added access to the following RPC functions:

- account_get
- account_info
- account_key
- validate_account_number
- all of the conversions (eg. rai_to_raw, rai_from_raw, etc.)

These commands are currently used on the PocketNano server but that will be phased out once these commands are added to Canoed. Follows the same format as the other Rainode calls, but all of the conversions are bunched up for convenience.